### PR TITLE
Add cmake target dependencies of the executable/library to ensure that

### DIFF
--- a/PNPros/ROS_bridge/pnp_ros/CMakeLists.txt
+++ b/PNPros/ROS_bridge/pnp_ros/CMakeLists.txt
@@ -123,6 +123,9 @@ add_library(aamas
    ${BOOST_LIBRARIES}
  )
 
+## Add cmake target dependencies of the executable/library
+ add_dependencies(aamas pnp_msgs_gencpp)
+
 add_library(PNPAS src/PNPActionServer.cpp)
 target_link_libraries(PNPAS
    aamas
@@ -135,8 +138,7 @@ target_link_libraries(PNPAS
  add_executable(pnp_node src/main.cpp)
 
 ## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(pnp_node pnp_generate_messages_cpp)
+ add_dependencies(pnp_node pnp_msgs_gencpp)
 
 ## Specify libraries to link a library or executable target against
  target_link_libraries(pnp_node

--- a/PNPros/example/tug_example_actions/CMakeLists.txt
+++ b/PNPros/example/tug_example_actions/CMakeLists.txt
@@ -106,8 +106,7 @@ include_directories(
 add_executable(example_actions_node src/example_actions_node.cpp)
 
 ## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(tug_example_actions_node tug_example_actions_generate_messages_cpp)
+add_dependencies(example_actions_node tug_example_msgs_gencpp)
 
 ## Specify libraries to link a library or executable target against
  target_link_libraries(example_actions_node


### PR DESCRIPTION
the required messages/services/actions are generated previously.

Avoids the compilation errors mentioned in the README file
