### PR TITLE
Fixing inconsitent IDs in ros bridge

### DIFF
--- a/PNPros/ROS_bridge/pnp_ros/include/pnp_ros/ActionProxy.h
+++ b/PNPros/ROS_bridge/pnp_ros/include/pnp_ros/ActionProxy.h
@@ -30,6 +30,7 @@ namespace pnpros
 			
             actionlib::ClientGoalHandle<pnp_msgs::PNPAction> goalhandler;
 			std::string robotname, name, params, id;
+            unsigned long long iid;
 			
             void feedbackCb(actionlib::ClientGoalHandle<pnp_msgs::PNPAction> gh,const pnp_msgs::PNPFeedbackConstPtr& feedback);
             void transitionCb(actionlib::ClientGoalHandle<pnp_msgs::PNPAction> gh);

--- a/PNPros/ROS_bridge/pnp_ros/include/pnp_ros/ActionProxy.h
+++ b/PNPros/ROS_bridge/pnp_ros/include/pnp_ros/ActionProxy.h
@@ -31,6 +31,7 @@ namespace pnpros
             actionlib::ClientGoalHandle<pnp_msgs::PNPAction> goalhandler;
 			std::string robotname, name, params, id;
             unsigned long long iid;
+            bool active;
 			
             void feedbackCb(actionlib::ClientGoalHandle<pnp_msgs::PNPAction> gh,const pnp_msgs::PNPFeedbackConstPtr& feedback);
             void transitionCb(actionlib::ClientGoalHandle<pnp_msgs::PNPAction> gh);

--- a/PNPros/ROS_bridge/pnp_ros/src/ActionProxy.cpp
+++ b/PNPros/ROS_bridge/pnp_ros/src/ActionProxy.cpp
@@ -16,11 +16,11 @@ namespace pnpros
 	ActionProxy::ActionProxy(const string& nm)
 	{
 		maxID++;
-		
+        iid = maxID;
 		stringstream ss; ss << maxID;
 		id = ss.str();
 		robotname = "";
-    string nms = nm;
+        string nms = nm;
 
 		// cerr << "Parsing: " << nm << " " << nm.find('_') << endl;
 
@@ -116,7 +116,7 @@ namespace pnpros
 		
         pnp_msgs::PNPGoal goal;
         ROS_DEBUG_STREAM("ActionProxy Robotname "<<robotname);
-		goal.id = maxID;
+        goal.id = iid;
 		goal.robotname = robotname;
 		goal.name = name;
 		goal.params = params;
@@ -169,7 +169,7 @@ namespace pnpros
 
         pnp_msgs::PNPGoal goal;
 
-		goal.id = maxID;
+        goal.id = iid;
         goal.robotname = robotname;
 		goal.name = name;
 		goal.params = params;
@@ -222,8 +222,8 @@ namespace pnpros
 
         pnp_msgs::PNPGoal goal;
 
-		goal.id = maxID;
-    goal.robotname = robotname;
+        goal.id = iid;
+        goal.robotname = robotname;
 		goal.name = name;
 		goal.params = params;
 		goal.function = "interrupt";

--- a/PNPros/ROS_bridge/pnp_ros/src/ActionProxy.cpp
+++ b/PNPros/ROS_bridge/pnp_ros/src/ActionProxy.cpp
@@ -11,7 +11,6 @@ namespace pnpros
 	ros::Publisher ActionProxy::publisher;
 	set<string> ActionProxy::activeActions;
 	unsigned long long ActionProxy::maxID;
-    bool active;
 	
 	ActionProxy::ActionProxy(const string& nm)
 	{


### PR DESCRIPTION
Closes #7 

The ID for the goals was created from `maxID` which is static and has therefore been increased with every new instance of the `ActionProxy` class. Hence, the `end` goal never had the same id as the `start` goal for concurrent actions. I introduced a new variable `iid` (short for integer id) which saves `maxID` during the creation of the instance locally. I could have used a `sstream` to get the int from the `id` as well but that seemed unnecessarily complicated.

This fixes the inconsistent IDs between `start` and `end` but it does not solve the problem that `end` is not always sent. I'll investigate further on this issue.

P.S.: Sorry for the messed up indentation but the whole file is a wild mix of tabs an spaces.