### PR TITLE
Adding the option of addressing failing action during plan generation

### DIFF
--- a/PNPgen/src/pnpgenerator.cpp
+++ b/PNPgen/src/pnpgenerator.cpp
@@ -342,6 +342,17 @@ Transition* PNP::addInterrupt(Place *pi, string condition, Place *po) {
     return ts;
 }
 
+Transition* PNP::addFail(Place *pi, Place *po) {
+    Node *pe = next(next(pi)); // exec place
+    string ae=pe->getName();
+    std::size_t pos = ae.find(".");      // position of "." in str
+    std::string a = ae.substr(0,pos);
+    Transition *ts = addTransition(a+".fail");
+    ts->setY(pe->getY()-1); ts->setX(pe->getX()); // upper line wrt pe
+    connect(pe,ts); connect(ts,po);
+    return ts;
+}
+
 Place* PNP::addAction(string name, Place *p0) {
     Transition *ts = addTransition(name+".start");
     Place *pe = addPlace(name+".exec");
@@ -691,8 +702,11 @@ void PNPGenerator::applyExecutionRules() {
                     po = pi;
                 }
 
-                
-                Transition *tsi = pnp.addInterrupt(current_place,eit->condition,pi);
+                Transition *tsi;
+                if(eit->condition=="action_failed")
+                    tsi = pnp.addFail(current_place,pi);
+                else
+                    tsi = pnp.addInterrupt(current_place,eit->condition,pi);
                 
                 cout << "DEBUG: checking for wait parallel actions of action " << current_action_param << endl;
                 if (pnp.timed_action_wait_exec_place.find(current_action_param)!=pnp.timed_action_wait_exec_place.end()) {

--- a/PNPgen/src/pnpgenerator.h
+++ b/PNPgen/src/pnpgenerator.h
@@ -165,6 +165,7 @@ public:
 
     Place* addTimedAction(string name, Place *p0, int timevalue, Place **p0action);
     Transition* addInterrupt(Place *pi, string condition, Place *po);
+    Transition* addFail(Place *pi, Place *po);
     void connectActionToPlace(Place *pi, Place *po); // connect the action and the place with an empty transition
     void connectPlaces(Place *pi, Place *po); // connect the two places with an empty transition
 


### PR DESCRIPTION
Adding the option of dealing with failing actions during PNP generation via execution rules.

Given the plan `goto_forward|5; say_hello|2` and the execution rules:

```
*if* action_failed *during* goto *do* restart_action
*if* robot_dist_far *during* say *do* restart_action
```

It now creates this plan:

![pnp5](https://cloud.githubusercontent.com/assets/4293484/17438082/f9b73414-5b18-11e6-92bf-48a008d21307.png)

Therefore, when the action reports failure upon completion the recovery is triggered. This reserves the term `action_failed` for conditions to mark which recovery should be executed when the action fails.
