### PR TITLE
Build in one go in a catkin workspace

### DIFF
--- a/PNPgen/CMakeLists.txt
+++ b/PNPgen/CMakeLists.txt
@@ -50,3 +50,5 @@ install(TARGETS pnpgen prumdp pnpgen_linear pnpgen_policy pnpgen_pru pnpgen_tran
   RUNTIME DESTINATION bin
 )
 
+install(DIRECTORY src/pnp_translator DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+install(FILES src/pnpgenerator.h src/conditionalplan.h src/policy.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/PNPgen/CMakeLists.txt
+++ b/PNPgen/CMakeLists.txt
@@ -50,5 +50,3 @@ install(TARGETS pnpgen prumdp pnpgen_linear pnpgen_policy pnpgen_pru pnpgen_tran
   RUNTIME DESTINATION bin
 )
 
-install(DIRECTORY src/pnp_translator DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
-install(FILES src/pnpgenerator.h src/conditionalplan.h src/policy.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/PNPros/ROS_bridge/pnp_ros/CMakeLists.txt
+++ b/PNPros/ROS_bridge/pnp_ros/CMakeLists.txt
@@ -92,7 +92,7 @@ catkin_package(
 ###########
 
 find_library(PNP_LIBRARY NAMES pnp PATHS $ENV{PNP_LIB})
-
+get_filename_component(PNP_LIBRARY_DIR ${PNP_LIBRARY} DIRECTORY CACHE)
 
 
 ## Specify additional locations of header files
@@ -102,9 +102,9 @@ include_directories(
   $ENV{PNP_INCLUDE}
   ${catkin_INCLUDE_DIRS}
   ${BOOST_INCLUDE_DIRS}
+  ${PNP_LIBRARY_DIR}/../include
 )
 link_directories($ENV{PNP_LIB})
-#message(include_var $ENV{PNP_INCLUDE})
 
 ## Declare a cpp library
 add_library(pnpros

--- a/PNPros/ROS_bridge/pnp_rosplan/CMakeLists.txt
+++ b/PNPros/ROS_bridge/pnp_rosplan/CMakeLists.txt
@@ -112,14 +112,20 @@ catkin_package(
 ## Build ##
 ###########
 
+find_library(PNP_LIBRARY NAMES pnp PATHS $ENV{PNP_LIB})
+get_filename_component(PNP_LIBRARY_DIR ${PNP_LIBRARY} DIRECTORY CACHE)
+find_library(PNPGEN_LIBRARY NAMES pnpgen PATHS $ENV{PNP_LIB})
+
+
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include)
 include_directories(
   ${pnp_ros_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-#  $ENV{PNP_INCLUDE}/../../PNPgen/src
-#  $ENV{PNP_INCLUDE}/../../PNPgen/src/pnp_translator
+  $ENV{PNP_INCLUDE}/../../PNPgen/src
+  $ENV{PNP_INCLUDE}/../../PNPgen/src/pnp_translator
+  ${PNP_LIBRARY_DIR}/../include
 )
 #link_directories($ENV{PNPGEN_LIB})
 
@@ -142,7 +148,7 @@ include_directories(
 
 ## Specify libraries to link a library or executable target against
  target_link_libraries(pnp_rosplan_node
-   pnpgen
+   ${PNPGEN_LIBRARY}
    ${catkin_LIBRARIES}
    ${pnpgen_LIBRARIES}
  )

--- a/PNPros/example/tug_example_pnp_server/CMakeLists.txt
+++ b/PNPros/example/tug_example_pnp_server/CMakeLists.txt
@@ -92,12 +92,20 @@ catkin_package(
 ## Build ##
 ###########
 
+find_library(PNP_LIBRARY NAMES pnp PATHS $ENV{PNP_LIB})
+get_filename_component(PNP_LIBRARY_DIR ${PNP_LIBRARY} DIRECTORY CACHE)
+
+
+
+
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
  include_directories(include)
 include_directories(
   $ENV{PNP_INCLUDE}
   ${catkin_INCLUDE_DIRS}
+  ${PNP_LIBRARY_DIR}/../include
+
 )
 
 ## Declare a cpp library


### PR DESCRIPTION
some fixes so that PNP builds nicely in a catkin devel workspace without requiring to build PNP and PNPgen separately before.